### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a static vanilla JavaScript web application (no backend/database). All game data is loaded via `fetch()` from JSON files in `data/`.
+
+### Services
+
+| Service | Command | Notes |
+|---------|---------|-------|
+| Static file server | `npx serve -l 3000 /workspace` | Required to serve the app; `fetch()` calls fail under `file://` protocol |
+| Tests | `yarn test` | Jest + jsdom, 152 tests |
+| CSS build | `yarn build:css` | TailwindCSS; only needed when modifying `styles.css` |
+
+### Caveats
+
+- The app uses ES modules (`<script type="module">`) and `fetch()` for JSON data, so a local HTTP server is required for browser testing.
+- The game starts with a skill allocation modal. To reach story content, complete the skill allocation or use the browser console to dismiss the modal.
+- See `package.json` `scripts` for all available commands (`test`, `build:css`, `sort`, `missing`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for developing this codebase.

### What this includes
- Service table (static file server, tests, CSS build) with commands
- Key caveats: ES module `fetch()` requires HTTP server, skill allocation modal on game start

### Environment verification

All checks pass:
- `yarn install` - dependencies install cleanly
- `yarn test` - all 152 Jest tests pass
- `yarn build:css` - TailwindCSS compiles successfully
- Static file server (`npx serve`) serves the app and JSON data files correctly
- Game loads in Chrome, skill allocation modal displays, story entries render, and navigation between entries works

[Game loaded with skill allocation modal](https://cursor.com/agents/bc-228325e4-477d-479a-930c-1bf4bce7157a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgame_loaded_skill_allocation.webp)
[Story entry 1 with telegram handout](https://cursor.com/agents/bc-228325e4-477d-479a-930c-1bf4bce7157a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgame_story_entry1.webp)
[Entry 102 with navigation choices](https://cursor.com/agents/bc-228325e4-477d-479a-930c-1bf4bce7157a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgame_entry102_choices.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-228325e4-477d-479a-930c-1bf4bce7157a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-228325e4-477d-479a-930c-1bf4bce7157a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

