### PR TITLE
P0 Fix: Export getCurrentEntryId() to resolve ReferenceError in index.js

### DIFF
--- a/src/game/gameActions.js
+++ b/src/game/gameActions.js
@@ -292,6 +292,10 @@ const locationCoordinates = {
 let currentPulseDot = null // Store the current pulsing dot for later updates
 let currentEntryId = null // Store the current entry id to use for repositioning
 
+export function getCurrentEntryId() {
+  return currentEntryId
+}
+
 export function highlightCurrentLocationOnMap(entryId) {
   const mapContainer = document.getElementById('minimap-container')
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import {
   loadGame,
   showMinimapIfPiecesExist,
   highlightCurrentLocationOnMap,
+  getCurrentEntryId,
 } from './game/gameActions.js'
 import { showSkillAllocationModal } from './game/gameUI.js'
 
@@ -20,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .addEventListener('click', function () {
       this.classList.toggle('expanded')
 
-      highlightCurrentLocationOnMap(currentEntryId)
+      highlightCurrentLocationOnMap(getCurrentEntryId())
     })
 
   // Add event listeners for opening and closing the inventory panel


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`src/index.js:23` references `currentEntryId`, which is a module-private `let` in `gameActions.js:293`. Since ES modules have their own scope, this variable is `undefined` in `index.js`, causing a `ReferenceError` whenever the minimap container is clicked.

## Fix

- Added `getCurrentEntryId()` getter function exported from `gameActions.js`
- Updated `index.js` to import and call `getCurrentEntryId()` instead of referencing the undefined variable

## Testing

- All 152 existing tests pass
- Browser test confirms no `ReferenceError` when minimap click handler fires

[Game loads without ReferenceError](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-currentEntryId.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

