### PR TITLE
P0 Fix: Combat health clamp operator precedence bug

### DIFF
--- a/src/game/gameActions.js
+++ b/src/game/gameActions.js
@@ -2111,7 +2111,7 @@ function handleCombatRound(actionType) {
 
           const damageToOpponent = parseAndComputeDamage(unarmedStrike)
 
-          if (opponent.health > 0 - damageToOpponent < 0) {
+          if (opponent.health - damageToOpponent < 0) {
             opponent.health = 0
           } else {
             opponent.health -= damageToOpponent
@@ -2151,7 +2151,7 @@ function handleCombatRound(actionType) {
 
           const damageToOpponent = parseAndComputeDamage(weaponDamage)
 
-          if (opponent.health > 0 - damageToOpponent < 0) {
+          if (opponent.health - damageToOpponent < 0) {
             opponent.health = 0
           } else {
             opponent.health -= damageToOpponent


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `handleCombatRound`, the health clamp condition:
```javascript
if (opponent.health > 0 - damageToOpponent < 0)
```
parses as `((health > 0) - damage) < 0` due to JavaScript operator precedence. This means the condition is always `false` for damage >= 2, allowing opponent health to go negative instead of clamping to 0.

Affected lines: `gameActions.js:2114` (unarmed) and `gameActions.js:2154` (handgun).

## Fix

Changed both instances to:
```javascript
if (opponent.health - damageToOpponent < 0)
```

## Proof

The screenshot below demonstrates the bug and fix with concrete examples:

[Combat precedence bug proof](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-combat-precedence.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

