### PR TITLE
P0 Fix: Book shop includes() compares objects to strings

### DIFF
--- a/src/game/gameActions.js
+++ b/src/game/gameActions.js
@@ -971,7 +971,7 @@ function handleSpecialEntry54(choicesContainer) {
 
   // Loop through the available books and exclude books already in the inventory
   books.forEach((book) => {
-    if (!inventoryBooks.includes(book.name)) {
+    if (!inventoryBooks.some((item) => item.name === book.name)) {
       // Only allow selecting books not in the player's inventory and if selectedBooks < 3
       if (selectedBooks < 3) {
         const bookButton = createButton(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `handleSpecialEntry54` (`gameActions.js:974`), `inventoryBooks` is an array of item **objects** (e.g., `{name: "Necronomicon", type: "book"}`), but the code used `inventoryBooks.includes(book.name)` which compares objects to a **string** using strict equality — always returning `false`.

This meant the "already purchased" filter never worked, allowing players to re-buy books they already owned.

## Fix

Changed to `inventoryBooks.some((item) => item.name === book.name)` to properly match by the `name` property.

## Proof

[Book shop bug explanation](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-bookshop-includes.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

