### PR TITLE
P0 Fix: Custom roll inventory check compares objects to strings

### DIFF
--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -49,8 +49,8 @@ export function performCustomRoll() {
     'the-symbol',
   ]
   clues.forEach((clue) => {
-    if (currentState.inventory.includes(clue)) {
-      totalBonus += 20 // Add 20 if any of the clues are in the inventory
+    if (currentState.inventory.some((item) => item.name === clue)) {
+      totalBonus += 20
     }
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `performCustomRoll` (`dice.js:52`), `currentState.inventory` is an array of item **objects** (e.g., `{name: "the-symbol", type: "clue"}`), but the code used `inventory.includes(clue)` where `clue` is a string. Since `===` between an object and a string is always `false`, the +20 clue bonus for having specific items never applied to the custom roll.

## Fix

Changed to `currentState.inventory.some((item) => item.name === clue)` for proper name-based matching.

## Proof

[Dice inventory bug explanation](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-dice-inventory.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

