### PR TITLE
P0 Fix: Remove duplicate DOMContentLoaded initialization in gameUI.js

### DIFF
--- a/src/game/gameUI.js
+++ b/src/game/gameUI.js
@@ -1,5 +1,5 @@
-import { initializeGame, gameData, currentState } from './gameState.js'
-import { saveGame, loadGame, checkRequirements } from './gameActions.js'
+import { gameData, currentState } from './gameState.js'
+import { checkRequirements } from './gameActions.js'
 
 // Add a function to create and manage the skill allocation modal
 export function showSkillAllocationModal(investigatorName) {
@@ -597,10 +597,3 @@ export function displayEntry(entryId) {
     }
   })
 }
-
-document.addEventListener('DOMContentLoaded', () => {
-  initializeGame()
-
-  document.getElementById('saveButton').onclick = saveGame
-  document.getElementById('loadButton').onclick = loadGame
-})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`gameUI.js:601-606` registered its own `DOMContentLoaded` handler that called `initializeGame()` and wired save/load buttons, competing with the real entry point in `index.js:10-44`. This could cause double initialization depending on module load order.

## Fix

- Removed the duplicate `DOMContentLoaded` handler from `gameUI.js`
- Cleaned up now-unused imports (`initializeGame`, `saveGame`, `loadGame`)
- `index.js` remains the single entry point for bootstrapping

## Proof

Game loads correctly with only `index.js` as the bootstrapping entry point:

[Game loads with single entry point](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-duplicate-domcontentloaded.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

