### PR TITLE
P0 Fix: Nested DOMContentLoaded that never fires + await initializeGame

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import {
 } from './game/gameActions.js'
 import { showSkillAllocationModal } from './game/gameUI.js'
 
-document.addEventListener('DOMContentLoaded', () => {
-  initializeGame()
+document.addEventListener('DOMContentLoaded', async () => {
+  await initializeGame()
 
   // Show skill allocation modal for the first investigator
   showSkillAllocationModal('Professor Grunewald')
@@ -27,9 +27,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('inventoryButton').addEventListener('click', () => {
     const inventoryPanel = document.getElementById('inventoryPanel')
     if (inventoryPanel.classList.contains('open')) {
-      inventoryPanel.classList.remove('open') // Close if it's already open
+      inventoryPanel.classList.remove('open')
     } else {
-      inventoryPanel.classList.add('open') // Open if it's closed
+      inventoryPanel.classList.add('open')
     }
   })
 
@@ -37,8 +37,5 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('inventoryPanel').classList.remove('open')
   })
 
-  document.addEventListener('DOMContentLoaded', () => {
-    // Call this to set initial visibility of the minimap
-    showMinimapIfPiecesExist()
-  })
+  showMinimapIfPiecesExist()
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`src/index.js:40-43` registered a **nested** `DOMContentLoaded` listener inside the outer one. Since the event already fired when the outer listener ran, the inner listener never triggered — making `showMinimapIfPiecesExist()` dead code at startup.

Additionally, `initializeGame()` is `async` but was called without `await`, meaning subsequent code ran before game data was loaded.

## Fix

- Removed the nested listener, calling `showMinimapIfPiecesExist()` directly at the end of the init block
- Made the outer listener `async` and added `await` to `initializeGame()` so game state is fully populated before `showMinimapIfPiecesExist()` runs

## Proof

Game loads cleanly with no `pyramidPieces` error (which would occur if `showMinimapIfPiecesExist()` ran before state was initialized):

[Game loads with proper init ordering](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-nested-domcontentloaded.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

