### PR TITLE
P1 Fix: multipleChecks reads check parameters from wrong object

### DIFF
--- a/src/game/gameActions.js
+++ b/src/game/gameActions.js
@@ -1260,11 +1260,11 @@ export function makeChoice(nextEntry, effects) {
           check.skill,
           currentState.skills,
           currentState,
-          effects.check?.difficulty || 'normal',
-          effects.check?.tries || null,
-          effects.check?.opposedValue || null,
-          effects.check?.bonus || 0,
-          effects.check?.penaltyDice || 0,
+          check.difficulty || 'normal',
+          check.tries || null,
+          check.opposedValue || null,
+          check.bonus || 0,
+          check.penaltyDice || 0,
         )
 
         currentState.results = currentState.results || {} // Initialize if not present


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `makeChoice` (`gameActions.js:1257-1268`), the `effects.multipleChecks` loop reads `difficulty`, `tries`, `opposedValue`, `bonus`, and `penaltyDice` from `effects.check` (a separate single-check config object) instead of from each individual `check` in the loop.

This meant all checks in a `multipleChecks` array used the same (wrong) parameters instead of their own per-check settings.

## Fix

Changed all five parameter reads from `effects.check?.X` to `check.X` to use each check's own properties.

## Proof

[multipleChecks parameter source bug](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-multipleChecks.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

