### PR TITLE
P1 Fix: fullHealth check and 'fully restored' message use hardcoded 100

### DIFF
--- a/src/game/gameActions.js
+++ b/src/game/gameActions.js
@@ -1320,15 +1320,14 @@ export function makeChoice(nextEntry, effects) {
 }
 
 export function updateHealth(amount) {
-  // Only adjust if there is actual damage (negative values)
+  const initialHealth = gameData.investigators[currentState.character].health
+
   if (amount < 0) {
     currentState.health += amount
     if (currentState.health < 0) {
-      currentState.health = 0 // Prevent health from going negative
+      currentState.health = 0
     }
   } else if (amount > 0) {
-    // Handle healing but cap it at the current character's max initial health
-    const initialHealth = gameData.investigators[currentState.character].health
     currentState.health = Math.min(currentState.health + amount, initialHealth)
   }
   document.getElementById('health').innerText = `Health: ${currentState.health}`
@@ -1338,7 +1337,7 @@ export function updateHealth(amount) {
       ? `Health increased by ${amount}`
       : `Health decreased by ${Math.abs(amount)}`
   if (amount !== 0) {
-    if (currentState.health === 100) {
+    if (currentState.health >= initialHealth) {
       updateMarker('healthMarker', 'Health fully restored!')
     } else {
       updateMarker('healthMarker', message)
@@ -1621,7 +1620,9 @@ export function checkRequirements(requirements) {
       }
     }
     if (requirements.fullHealth) {
-      if (currentState.health < 100) {
+      const initialHealth =
+        gameData.investigators[currentState.character].health
+      if (currentState.health < initialHealth) {
         return false
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two places used hardcoded `100` for health comparisons, but each investigator has a different max health (e.g., Grunewald=9, Holt=11):

1. **`checkRequirements`** (`gameActions.js:1623-1626`): `currentState.health < 100` — the `fullHealth` requirement was impossible to satisfy for any character
2. **`updateHealth`** (`gameActions.js:1341`): `currentState.health === 100` — the "Health fully restored!" message never displayed

## Fix

Both now use `gameData.investigators[currentState.character].health` to get the per-character max health, consistent with the healing cap logic already in `updateHealth`.

## Proof

[fullHealth hardcoded 100 bug](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-fullhealth.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

