### PR TITLE
P1 Fix: Remove duplicate minHotelStays block in checkRequirements

### DIFF
--- a/src/game/gameActions.js
+++ b/src/game/gameActions.js
@@ -1782,40 +1782,17 @@ export function checkRequirements(requirements) {
       const { moderateHotelStays, expensiveHotelStays } =
         requirements.minHotelStays
 
-      // Check for minimum moderateHotelStays
       if (moderateHotelStays !== undefined) {
-        const playerModerateStays = currentState.moderateHotelStays || 0 // Default to 0 if undefined
+        const playerModerateStays = currentState.moderateHotelStays || 0
         if (playerModerateStays < moderateHotelStays) {
-          return false // Player hasn't met the minimum moderate stays requirement
+          return false
         }
       }
 
-      // Check for minimum expensiveHotelStays
       if (expensiveHotelStays !== undefined) {
-        const playerExpensiveStays = currentState.expensiveHotelStays || 0 // Default to 0 if undefined
+        const playerExpensiveStays = currentState.expensiveHotelStays || 0
         if (playerExpensiveStays < expensiveHotelStays) {
-          return false // Player hasn't met the minimum expensive stays requirement
-        }
-      }
-    }
-
-    if (requirements.minHotelStays) {
-      const { moderateHotelStays, expensiveHotelStays } =
-        requirements.minHotelStays
-
-      // Check for minimum moderateHotelStays
-      if (moderateHotelStays !== undefined) {
-        const playerModerateStays = currentState.moderateHotelStays || 0 // Default to 0 if undefined
-        if (playerModerateStays < moderateHotelStays) {
-          return false // Player hasn't met the minimum moderate stays requirement
-        }
-      }
-
-      // Check for minimum expensiveHotelStays
-      if (expensiveHotelStays !== undefined) {
-        const playerExpensiveStays = currentState.expensiveHotelStays || 0 // Default to 0 if undefined
-        if (playerExpensiveStays < expensiveHotelStays) {
-          return false // Player hasn't met the minimum expensive stays requirement
+          return false
         }
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The exact same `if (requirements.minHotelStays)` block was copy-pasted back-to-back in `checkRequirements` (lines 1781-1821). The second copy was pure redundancy.

## Fix

Removed the duplicate block. 23 lines of dead duplication deleted. Behavior is unchanged.

## Proof

[Duplicate minHotelStays block](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-duplicate-minHotelStays.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

