### PR TITLE
P2: Add test coverage metrics to Jest configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 sorted_entries.json
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,14 @@
 module.exports = {
-  testEnvironment: "jsdom",
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   transform: {
-    "^.+\\.[tj]sx?$": "babel-jest",
+    '^.+\\.[tj]sx?$': 'babel-jest',
   },
-};
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'text-summary', 'lcov'],
+  collectCoverageFrom: [
+    'src/**/*.js',
+    '!src/assets/**',
+  ],
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Jest had no coverage configuration — there was no visibility into which code was tested and which wasn't.

## Changes

- Enabled `collectCoverage` in `jest.config.js`
- Added `text`, `text-summary`, and `lcov` reporters
- Scoped coverage to `src/**/*.js`
- Added `coverage/` to `.gitignore`

## Coverage Baseline

[Test coverage metrics](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fadd-coverage.png)

| File | Statements | Branches | Functions | Lines |
|------|-----------|----------|-----------|-------|
| **All files** | 54.19% | 51.69% | 57.92% | 54.45% |
| gameState.js | 90.76% | 60% | 100% | 90.62% |
| storage.js | 85.71% | 50% | 100% | 85.71% |
| gameUI.js | 64.73% | 40.47% | 62.5% | 65.02% |
| gameActions.js | 51.84% | 52.05% | 55.55% | 51.96% |
| dice.js | 43.56% | 54.09% | 30% | 44.82% |
| index.js | 0% | 0% | 0% | 0% |

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

