### PR TITLE
P3: Migrate Tailwind config from purge:[] to content with proper paths

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,24 +1,20 @@
 module.exports = {
-  purge: [],
-  darkMode: false, // or 'media' or 'class'
+  content: ['./*.html', './src/**/*.js'],
   theme: {
     extend: {
       fontFamily: {
-        sans: ['"Libre Baskerville"', "serif"],
-        display: ['"Cinzel"', "serif"],
+        sans: ['"Libre Baskerville"', 'serif'],
+        display: ['"Cinzel"', 'serif'],
       },
       colors: {
-        gold: "#d4af37",
-        navy: "#000080",
+        gold: '#d4af37',
+        navy: '#000080',
       },
     },
     container: {
       center: true,
-      padding: "2rem",
+      padding: '2rem',
     },
   },
-  variants: {
-    extend: {},
-  },
   plugins: [],
-};
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`tailwind.config.js` had `purge: []` (empty array), meaning no CSS tree-shaking occurred. The output CSS included all of Tailwind's utility classes. Also used deprecated Tailwind v2 keys (`darkMode`, `variants`).

## Changes

- Changed `purge: []` to `content: ['./*.html', './src/**/*.js']` for proper tree-shaking
- Removed deprecated Tailwind v2 keys (`darkMode`, `variants`)
- Fixed formatting to match project conventions

## Proof

[Tailwind config migration](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffix-tailwind.png)

Build output is now ~915 lines (only used classes) vs thousands previously.

## Testing

All 152 existing tests pass. `npx tailwindcss -i styles.css -o output.css` builds successfully.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

