### PR TITLE
P3: Remove debug console.log calls + fix non-portable script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:css": "npx tailwindcss build styles.css -o output.css",
     "test": "jest",
     "sort": "node scripts/sortJson.js",
-    "missing": "cd scripts && node nextEntries.js && node topLevelEntries.js && node missingEntries.js && cd output && code missingEntries.json"
+    "missing": "cd scripts && node nextEntries.js && node topLevelEntries.js && node missingEntries.js"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/src/game/gameActions.js
+++ b/src/game/gameActions.js
@@ -132,7 +132,6 @@ export function displayEntry(entryId) {
   updateMinimapProgress(entryId)
 
   if (lastDisplayedEntry === '187' && entryId === '10d') {
-    console.log('Prevented display of 10d following 187')
     return // Prevent the specific unwanted transition
   }
 
@@ -666,7 +665,6 @@ export function handleEntryChoices(entryId, entry) {
 
               // Handle scheduling a meeting
               if (choice.effects.scheduleMeeting) {
-                console.log(choice.effects.scheduleMeeting)
                 if (!currentState.scheduledMeetings) {
                   currentState.scheduledMeetings = []
                 }
@@ -765,7 +763,6 @@ export function handleComplexOutcome(checkResult) {
   }
 
   if (checkResult.dexterity) {
-    console.log(currentState)
     currentState.DEX -= parseInt(checkResult.dexterity)
   }
 
@@ -1550,8 +1547,6 @@ export function loadGame() {
 
     updateCharacterImage()
     updateSkillsPanel() // <-- Add this line to update the sidebar after loading
-  } else {
-    console.log('No saved state found in localStorage.')
   }
 }
 
@@ -1930,7 +1925,6 @@ export function handleOutcomeBasedEncounter(choice) {
         .diceRoll
         ? rollDice(matchedOutcome.effects.setVariable.value.diceRoll)
         : matchedOutcome.effects.setVariable.value
-      console.log('set water level to ' + currentState.waterSupply)
       updateWaterSupplyDisplay(currentState.waterSupply) // Update the UI for water supply
     }
 
@@ -2080,7 +2074,6 @@ function startCombat(entryId, combatDetails) {
 
 function handleCombatRound(actionType) {
   if (!currentState.combat.isActive) {
-    console.log('Combat has already ended, exiting round.')
     return
   }
 
@@ -2117,16 +2110,11 @@ function handleCombatRound(actionType) {
             opponent.health -= damageToOpponent
           }
 
-          console.log(
-            `Player attacked successfully, new opponent health: ${opponent.health}`,
-          )
-
           updateHitMarker(
             document.getElementById('playerHitMarker'),
             `You hit opponent for ${damageToOpponent} damage!`,
           )
         } else {
-          console.log('Player attack failed.')
           updateHitMarker(
             document.getElementById('playerHitMarker'),
             'You missed!',
@@ -2157,16 +2145,11 @@ function handleCombatRound(actionType) {
             opponent.health -= damageToOpponent
           }
 
-          console.log(
-            `Player attacked successfully, new opponent health: ${opponent.health}`,
-          )
-
           updateHitMarker(
             document.getElementById('playerHitMarker'),
             `You hit opponent for ${damageToOpponent} damage!`,
           )
         } else {
-          console.log('Player attack failed.')
           updateHitMarker(
             document.getElementById('playerHitMarker'),
             'You missed!',
@@ -2199,16 +2182,12 @@ function handleCombatRound(actionType) {
           currentState.health -= damageToPlayer
         }
         updateHealthDisplay()
-        console.log(
-          `Opponent attacked successfully, new player health: ${currentState.health}`,
-        )
 
         updateHitMarker(
           document.getElementById('opponentHitMarker'),
           `Opponent hit you for ${damageToPlayer} damage!`,
         )
       } else {
-        console.log('Opponent attack failed.')
         updateHitMarker(
           document.getElementById('opponentHitMarker'),
           'Opponent missed!',
@@ -2219,11 +2198,9 @@ function handleCombatRound(actionType) {
 
   // Check for end of combat
   if (currentState.health <= 0) {
-    console.log('Player defeated, handling loss.')
     endCombat(currentState.combat.outcome.lose)
     return
   } else if (opponent.health <= 0) {
-    console.log('Opponent defeated, handling win.')
     endCombat(currentState.combat.outcome.win)
     return
   }
@@ -2231,22 +2208,18 @@ function handleCombatRound(actionType) {
   // Update combat status if still active
   if (currentState.combat.isActive) {
     updateCombatStatus()
-  } else {
-    console.log('Combat is not active post-round, no UI update required.')
   }
 }
 
 function endCombat(entry = null) {
   clearHitMarkers() // Clear the hit markers when combat ends
 
-  console.log(`Ending combat, transition to entry: ${entry}`)
   currentState.combat.isActive = false // Explicitly mark combat as inactive
   updateCombatStatus() // Update any UI or status indicators
 
   if (typeof entry === 'object') {
     handleComplexOutcome(entry)
   } else {
-    console.log(`Displaying victory/defeat entry: ${entry}`)
     setTimeout(() => displayEntry(entry), 100) // Use a slight delay to ensure all combat processes have ceased
   }
 }
@@ -2277,7 +2250,6 @@ function updateCombatStatus() {
       <br>Health: ${currentState.combat.opponent.health}/${currentState.combat.opponent.maxHealth}
       </p>
     `
-    console.log(currentState.combat.opponent.image)
     // Check if an image is provided for the opponent
     if (currentState.combat.opponent.image) {
       combatHtml += `
@@ -2380,7 +2352,6 @@ function checkIfDisembarked(choicesContainer) {
       () => {
         // Set the hour to Noon (12 PM)
         updateTime(0, 12)
-        console.log('Got off at Athens Pier, time set to Noon.')
         displayEntry('173')
       },
     )
@@ -2392,7 +2363,6 @@ function checkIfDisembarked(choicesContainer) {
       () => {
         // Advance the day and set the hour to 8AM
         updateTime(24)
-        console.log('Staying onboard, time advanced to 11 PM.')
         displayEntry('187')
       },
     )
@@ -2409,7 +2379,6 @@ function checkIfDisembarked(choicesContainer) {
       () => {
         // Set the time to 1 PM
         updateTime(0, 13)
-        console.log('Disembarked at Alexandria, time set to 1 PM.')
         displayEntry('195')
       },
     )
@@ -2429,15 +2398,6 @@ function saveSelectedActivities(amActivity, pmActivity, nightActivity) {
   }
 }
 
-function displaySelectedActivities() {
-  if (currentState.shipActivities) {
-    console.log('Your selected activities for today:')
-    console.log('AM:', currentState.shipActivities.am)
-    console.log('PM:', currentState.shipActivities.pm)
-    console.log('Night:', currentState.shipActivities.night)
-  }
-}
-
 function handleSpecialEntry187(choicesContainer) {
   const currentDate = getCurrentDate()
 
@@ -2451,11 +2411,9 @@ function handleSpecialEntry187(choicesContainer) {
       0,
       0, // Ensure the time is set to midnight
     )
-    console.log('Ship journey started on:', currentState.shipJourneyStartDate)
   }
 
   const journeyDay = calculateJourneyDay() // Calculate the current day of the journey
-  console.log('Journey day:', journeyDay)
 
   // Handle disembarkation if we're on specific days
   if (checkIfDisembarked(choicesContainer)) {
@@ -2534,11 +2492,6 @@ function handleSpecialEntry187(choicesContainer) {
       if (amActivity && pmActivity && nightActivity) {
         // Save selected activities
         saveSelectedActivities(amActivity, pmActivity, nightActivity)
-        console.log('Activities selected for Cunard Ship:', {
-          am: amActivity,
-          pm: pmActivity,
-          night: nightActivity,
-        })
 
         // Get the schedule entry for the current journey day and display it
         const journeyDay = calculateJourneyDay() // Recalculate the journey day

--- a/src/game/gameUI.js
+++ b/src/game/gameUI.js
@@ -91,7 +91,6 @@ export function showSkillAllocationModal(investigatorName) {
 
           // Ensure the modal is hidden after confirming skill allocation
           modal.style.display = 'none'
-          console.log('Skill allocation modal hidden.')
 
           // Update the skills side panel with the allocated skills
           updateSkillsPanel()

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -41,7 +41,6 @@ export function performCustomRoll() {
 
   const hoursRemaining = Math.max(0, (sixPM - currentTime) / (1000 * 60 * 60)) // Calculate remaining hours
   totalBonus += Math.floor(hoursRemaining) * 5 // Add 5 for each remaining hour
-  console.log(hoursRemaining)
   // Inventory logic: Check if player has the-symbol-of-the-cult-of-aten, clue207, or the-symbol
   const clues = [
     'the-symbol-of-the-cult-of-aten',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

1. ~30+ `console.log` debug statements scattered across source files (combat state, ship journeys, water supply, skill modal, etc.)
2. `package.json`'s `missing` script included `code missingEntries.json` which invokes VS Code and fails on headless/CI environments

## Changes

### Debug Logging Removed
- **gameActions.js**: ~30 console.log calls removed (combat, ship, water, meetings, etc.)
- **gameUI.js**: 1 console.log removed ("modal hidden")
- **dice.js**: 1 console.log removed (hoursRemaining debug)
- **gameState.js**: 3 game-over logs **kept** (useful user-facing information)
- All `console.error` calls preserved (legitimate error handling)

### Script Fix
- Removed `&& cd output && code missingEntries.json` from `missing` script (VS Code specific)

## Proof

[Debug logging cleanup summary](https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcleanup-logging.png)

## Testing

All 152 existing tests pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb802a-c465-4730-8133-c14794f9a914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

